### PR TITLE
Fix deployment action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -18,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Build
-        run: bun run build
+        run: bun run build && cp dist/index.html dist/404.html
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "@types/react-dom": "^19"
   },
   "engines": {
-    "bun": ">=1.2.20"
+    "bun": "1.2.20"
   }
 }


### PR DESCRIPTION
This pull request updates the deployment workflow and build process to improve reliability and ensure proper handling of static site routing, as well as tightening the required Bun engine version. The most important changes are grouped below:

**Deployment workflow improvements:**

* Added support for manual workflow dispatch and concurrency control in `.github/workflows/deploy.yaml` to prevent overlapping deployments.

**Build process enhancements:**

* Updated the build step in `.github/workflows/deploy.yaml` to copy `dist/index.html` to `dist/404.html`, ensuring custom 404 page support for static hosting.

**Dependency management:**

* Changed the Bun engine requirement in `package.json` from a range (`>=1.2.20`) to an exact version (`1.2.20`) for more predictable builds.